### PR TITLE
handle clone delete buttons

### DIFF
--- a/jquery-cloneya.js
+++ b/jquery-cloneya.js
@@ -66,7 +66,12 @@
             $.extend(config, lateoptions || {});
         };
         
-
+        var cloneCount = elem.find(config.cloneThis).length;
+        
+        if (cloneCount <= 2) {
+        	$(config.deleteButton).eq(0).hide();
+        }
+        
         // add a click handler for the clone button
         elem.on('click', config.cloneButton, function(event) {
             event.preventDefault();
@@ -139,6 +144,16 @@
                 // trigger a custom event for hooking
                 elem.trigger('clone_limit', config.limit, $toclone );
             }
+            
+            //handle clone delete buttons
+            if (cloneCount >= 1) {
+            	$(config.deleteButton).show();
+            }
+            
+            if (cloneCount >= config.limit-1) {
+            	$(config.cloneButton).eq(cloneCount).hide();
+            }
+            
 
         });
 
@@ -173,6 +188,16 @@
                 elem.trigger('clone_after_delete');
 
             }
+            
+            //handle clone delete buttons
+            
+            if (cloneCount <= 2) {
+            	$(config.deleteButton).eq(0).hide();
+            }
+            
+            if (cloneCount <= config.limit) {
+            	$(config.cloneButton).show();
+            }              
         });
 
         /**


### PR DESCRIPTION
When default view there is no need of the delete button or at the end of clone limit there is no need of add button. That might confuse user. You have already handle to keep at least one default field. But I added the code to handle the buttons also. I might not written that code in optimized way. But it's useful to have that functionality.
