### PR TITLE
#BUG: Solve serializedIndex bug 10+ elements

### DIFF
--- a/dist/jquery-cloneya.js
+++ b/dist/jquery-cloneya.js
@@ -422,14 +422,12 @@
                         var name = $(this).attr('name');
                         // This will increment the numeric array index for cloned field names
                         if (name) {
-                            var matches = name.match(/\[([^}]+)\]/);
+                            var matches = name.match(/\[([0-9}]+)\]/);
 
                             if (matches && matches.length >= 1) {
 
                                 var st = name;
-                                name = [].map.call(st, function (s, n) {
-                                    return (!isNaN(+s) && st[n - 1] === '[' && st[n + 1] === ']') ? i : s;
-                                }).join('');
+                                var name = st.replace(matches[0], "["+i+"]");
 
                                 $(this).attr('name', name);
                             }


### PR DESCRIPTION
#BUG: Solve index change error when option serializedIndex:true is setted and cloned more than ten elements

* The first bug correction propose is incorrect in regex (1-9). changed to (0-9) to catch all indexes